### PR TITLE
Add 'require "fileutils" to ruby script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cloud Platform Cost Calculator
 
+[![Releases](https://img.shields.io/github/release/ministryofjustice/cloud-platform-cost-calculator/all.svg?style=flat-square)](https://github.com/ministryofjustice/cloud-platform-cost-calculator/releases)
+
 Use [infracost] to work out the running costs of namespaces in the Cloud
 Platform, and post the data to [How Out Of Date Are We][hoodaw]
 

--- a/post-namespace-costs.rb
+++ b/post-namespace-costs.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require "fileutils"
 require "json"
 require "open3"
 


### PR DESCRIPTION
It seems this is a difference in the alpine ruby 2.7.1 versus the OSX
ruby 2.7.1, because on OSX you don't need this require in order to use
FileUtils.
