### PR TITLE
Don't log command & stdout

### DIFF
--- a/post-namespace-costs.rb
+++ b/post-namespace-costs.rb
@@ -120,9 +120,9 @@ def repo_url
 end
 
 def execute(cmd)
-  puts "CMD: #{cmd}"
+  # puts "CMD: #{cmd}"
   stdout, stderr, status = Open3.capture3(cmd)
-  puts "OUTPUT:\n#{stdout}"
+  # puts "OUTPUT:\n#{stdout}"
   unless status.success?
     puts "ERROR: #{stderr}"
     exit 1


### PR DESCRIPTION
We were using this to track down a problem, but it's no longer necessary
(and it leaks the HOODAW API token into the concourse logs, which is not
great).
