### PR TITLE
Change to run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,15 @@ RUN apk --no-cache add git curl ruby ruby-json
 
 RUN gem install aws-sdk-costexplorer
 
-WORKDIR /root
+RUN addgroup -g 1000 -S appgroup \
+  && adduser -u 1000 -S appuser -G appgroup
+
+WORKDIR /app
 
 RUN mkdir lib
 COPY post-namespace-costs.rb .
 COPY lib/* lib/
+
+RUN chown -R appuser:appgroup /app
+
+USER 1000


### PR DESCRIPTION
This change will enable this task to be run as a kubernetes cronjob in a
normal namespace, where root users are not permitted.

**Create release 2.1 after merging this PR**